### PR TITLE
Revert "use preprocessTree instead of prototype methods"

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
     this.app = app;
 
     this._initOptions();
+    this._injectFunnel();
   },
   _initOptions() {
     let defaultOptions = {
@@ -24,17 +25,51 @@ module.exports = {
       }
     }
   },
+  _injectFunnel() {
+    if (!this.options.enabled) {
+      return;
+    }
+
+    let options = this.options;
+
+    let appAndDependencies = this.app.appAndDependencies;
+    this.app.appAndDependencies = function() {
+      let tree = appAndDependencies.apply(this, arguments);
+
+      tree = new Funnel(tree, {
+        exclude: options.exclude,
+        description: 'Funnel (appAndDependencies): ' + this.name
+      });
+
+      return tree;
+    };
+
+    let _processedTestsTree = this.app._processedTestsTree;
+    this.app._processedTestsTree = function() {
+      let tree = _processedTestsTree.apply(this, arguments);
+
+      tree = new Funnel(tree, {
+        exclude: options.exclude,
+        description: 'Funnel (_processedTestsTree): ' + this.name
+      });
+
+      return tree;
+    };
+  },
 
   preprocessTree(type, tree) {
-    let options = this.options;
-    if (!options.enabled) {
+    if (!this.options.enabled) {
       return tree;
     }
 
-    tree = new Funnel(tree, {
-      exclude: options.exclude,
-      description: `Funnel (${type}): ${this.name}`
-    });
+    let options = this.options;
+
+    if (type === 'css') {
+      tree = new Funnel(tree, {
+        exclude: options.exclude,
+        description: 'Funnel (css): ' + this.name
+      });
+    }
 
     return tree;
   }


### PR DESCRIPTION
Reverts kellyselden/ember-cli-funnel#65

This doesn't account for addon trees.