### PR TITLE
Move `lib/my-addon` out of addon.paths in package.json

### DIFF
--- a/lib/my-addon/package.json
+++ b/lib/my-addon/package.json
@@ -1,5 +1,6 @@
 {
   "name": "my-addon",
+  "version": "0.0.0",
   "keywords": [
     "ember-addon"
   ]

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^6.0.1",
     "loader.js": "^4.2.3",
+    "my-addon": "file:./lib/my-addon",
     "qunit-dom": "^0.6.2"
   },
   "engines": {
@@ -46,8 +47,6 @@
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",
-    "paths": [
-      "lib/my-addon"
-    ]
+    "paths": []
   }
 }


### PR DESCRIPTION
In the Ember-CLI 3.4.x series, there is a new assertion that checks for the existence of each of the paths in the `addon.paths` section of an addon's package.json.

`ember-cli-funnel` includes `lib/my-addon` in that `paths` array, but it does not actually publish it to npm. As a result, ember-cli 3.4.x displays warnings on every build because of this missing directory, e.g.:

```
WARNING:
WARNING: /Users/cfreeman/envoy/garaje/node_modules/ember-cli-funnel/lib/my-addon:
WARNING:    Missing package directory
WARNING: For addon at path /Users/cfreeman/envoy/garaje/node_modules/ember-cli-funnel:
WARNING:    Excluding invalid/malformed/missing addon at relative path 'lib/my-addon'
```

Since it appears that this addon is solely used for testing (and thus shouldn't be published to npm), we can fix this warning my moving it out of `addon.paths` and instead of specifying it as a local-file devDependency.

The only other change I had to make was to add a `version` property to `lib/my-addon/package.json` because without it, yarn throws a fit and I'm assuming we'd like to avoid that.

*Note:* This PR is the result of a conversation with @rwjblue on Discord.